### PR TITLE
Fixing null pointer issue in core/interfaceutil.py 

### DIFF
--- a/responder3/core/interfaceutil.py
+++ b/responder3/core/interfaceutil.py
@@ -364,7 +364,8 @@ def get_linux_ifaddrs():
 				interfacesd[ifname] = NetworkInterface()
 				interfacesd[ifname].ifname = ifname
 				interfacesd[ifname].ifindex = libc.if_nametoindex(ifname)
-			family, addr = getfamaddr(ifa.ifa_addr.contents)
+			if ifa.ifa_addr:
+				family, addr = getfamaddr(ifa.ifa_addr.contents)
 			if family in [socket.SOCK_DGRAM, socket.SOCK_STREAM]:
 				interfacesd[ifname].addresses.append(ipaddress.ip_address(addr))
 		return interfacesd


### PR DESCRIPTION
To allow operation over tunneled/vpn interfaces. This issue appeared when attempting to run Responder3 over an OpenVPN tun/udp interface. Tested on Ubuntu 17.10 with Python3.6